### PR TITLE
feat:扩展CanvasSelect参数url的类型

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,7 +137,7 @@ export default class CanvasSelect extends EventBus {
      * @param el Valid CSS selector string, or DOM
      * @param src image src
      */
-    constructor(el: HTMLCanvasElement | string, src?: string) {
+    constructor(el: HTMLCanvasElement | string, src?:  string | HTMLImageElement) {
         super();
         this.handleLoad = this.handleLoad.bind(this);
         this.handleContextmenu = this.handleContextmenu.bind(this);
@@ -730,10 +730,20 @@ export default class CanvasSelect extends EventBus {
 
     /**
      * 添加/切换图片
-     * @param url 图片链接
+     * @param source 图片链接或图片对象
      */
-    setImage(url: string) {
-        this.image.src = url;
+    setImage(source: string | HTMLImageElement) {
+        if (typeof source === 'string') {
+            this.image.src = source;
+        } else {
+            this.image = source;
+            this.image.crossOrigin = 'anonymous';
+            if (this.image.complete) {
+                this.handleLoad();
+            } else {
+                this.image.addEventListener('load', this.handleLoad);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
主要对实例化时url类型进行扩展，可以传递Img实例。在一些大批量图片标注的情况，需要对图片进行预先缓存，来提高用户的体验。可以传递Img实例可以减少用户在当前标注页面的的等待。